### PR TITLE
Increased flexibility of allowed method signatures

### DIFF
--- a/core/src/main/scala/com/payalabs/scalajs/react/bridge/ReactBridgeComponent.scala
+++ b/core/src/main/scala/com/payalabs/scalajs/react/bridge/ReactBridgeComponent.scala
@@ -132,7 +132,7 @@ object ReactBridgeComponent {
     val props = {
       val params = c.internal.enclosingOwner.asMethod.paramLists.flatten.filter(!_.isImplicit)
       val convertedProps = params.map { param =>
-        val rawParamType = param.typeSignature
+        val rawParamType = c.typecheck(Ident(param.name)).tpe
         val converted = {
           if (rawParamType.typeConstructor == typeOf[scala.scalajs.js.UndefOr[Any]].typeConstructor) {
             val paramType = rawParamType.typeArgs.head

--- a/core/src/main/scala/com/payalabs/scalajs/react/bridge/ReactBridgeComponent.scala
+++ b/core/src/main/scala/com/payalabs/scalajs/react/bridge/ReactBridgeComponent.scala
@@ -130,7 +130,7 @@ object ReactBridgeComponent {
     import c.universe._
 
     val props = {
-      val params = c.internal.enclosingOwner.asMethod.paramLists.headOption.getOrElse(List())
+      val params = c.internal.enclosingOwner.asMethod.paramLists.flatten.filter(!_.isImplicit)
       val convertedProps = params.map { param =>
         val rawParamType = param.typeSignature
         val converted = {

--- a/core/src/test/scala/com/payalabs/scalajs/react/bridge/test/GenericComponent.scala
+++ b/core/src/test/scala/com/payalabs/scalajs/react/bridge/test/GenericComponent.scala
@@ -1,0 +1,13 @@
+package com.payalabs.scalajs.react.bridge.test
+
+import scala.scalajs.js
+
+import com.payalabs.scalajs.react.bridge.ReactBridgeComponent
+
+
+/**
+  * This is here to "test" (at compile-time) that ReactComponentBridge works with generics
+  */
+object GenericComponent extends ReactBridgeComponent {
+  def apply[A <: js.Any](param: A): Any = auto
+}


### PR DESCRIPTION
 - Fix error when using generics
 - Allow multiple parameter lists (implicits are not translated into props)