### PR TITLE
Added Scala 2.11 cross compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: scala
 scala:
    - 2.12.2
+   - 2.11.12

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ enablePlugins(ScalaJSPlugin)
 
 val core = project in file("core")
 
-scalaVersion := "2.12.2"
+crossScalaVersions := Seq("2.12.2", "2.11.12")
 
 version := "0.5.0-SNAPSHOT"
 
@@ -21,5 +21,3 @@ val scalaJsReactBridge = (project in file(".")).aggregate(
   publish := (),
   publishLocal := ()
 )
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ enablePlugins(ScalaJSPlugin)
 val core = project in file("core")
 
 crossScalaVersions := Seq("2.12.2", "2.11.12")
+scalaVersion := crossScalaVersions.value.head
 
 version := "0.5.0-SNAPSHOT"
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -7,7 +7,7 @@ name := "scalajs-react-bridge"
 
 version := "0.5.0-SNAPSHOT"
 
-scalaVersion := "2.12.2"
+crossScalaVersions := Seq("2.12.2", "2.11.12")
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -8,6 +8,7 @@ name := "scalajs-react-bridge"
 version := "0.5.0-SNAPSHOT"
 
 crossScalaVersions := Seq("2.12.2", "2.11.12")
+scalaVersion := crossScalaVersions.value.head
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
 

--- a/core/src/main/scala/com/payalabs/scalajs/react/bridge/package.scala
+++ b/core/src/main/scala/com/payalabs/scalajs/react/bridge/package.scala
@@ -41,22 +41,24 @@ package object bridge extends GeneratedImplicits {
   implicit def seqWriter[T: JsWriter]: JsWriter[Seq[T]] = {
     val elementWriter = implicitly[JsWriter[T]]
 
-    (value: Seq[T]) => js.Array(value.map(e => elementWriter.toJs(e)): _*)
+    JsWriter((value: Seq[T]) => js.Array(value.map(e => elementWriter.toJs(e)): _*))
   }
 
   implicit def immutableSeqWriter[T : JsWriter]: JsWriter[scala.collection.immutable.Seq[T]] = {
     val elementWriter = implicitly[JsWriter[T]]
 
-    (value: scala.collection.immutable.Seq[T]) => js.Array(value.map(e => elementWriter.toJs(e)): _*)
+    JsWriter((value: scala.collection.immutable.Seq[T]) => js.Array(value.map(e => elementWriter.toJs(e)): _*))
   }
 
   implicit def mapWriter[T : JsWriter]: JsWriter[Map[String, T]] = {
     val elementWriter = implicitly[JsWriter[T]]
 
-    (value: Map[String, T]) => {
-      val converted = value.map { case (k, v) => (k, elementWriter.toJs(v)) }
-      js.Dictionary(converted.toSeq: _*)
-    }
+    JsWriter(
+      (value: Map[String, T]) => {
+        val converted = value.map { case (k, v) => (k, elementWriter.toJs(v)) }
+        js.Dictionary(converted.toSeq: _*)
+      }
+    )
   }
 
   implicit def futureWriter[A](implicit writeA: JsWriter[A], executionContext: ExecutionContext): JsWriter[Future[A]] =

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,7 +4,7 @@ organization := "com.payalabs"
 name := "scalajs-react-bridge-example"
 version := "0.5.0-SNAPSHOT"
 
-scalaVersion := "2.12.2"
+crossScalaVersions := Seq("2.12.2", "2.11.12")
 
 libraryDependencies ++= {
   val scalaJsDom = "0.9.2"

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -5,6 +5,7 @@ name := "scalajs-react-bridge-example"
 version := "0.5.0-SNAPSHOT"
 
 crossScalaVersions := Seq("2.12.2", "2.11.12")
+scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies ++= {
   val scalaJsDom = "0.9.2"

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.18")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")


### PR DESCRIPTION
Added Scala 2.11 cross compile so that the library can be used by Scala 2.11 based projects.

In order to use the latest version of 2.11 (2.11.12) I bumped the version of Scala.js to the latest (0.6.22). Scala 2.11 doesn't support using lambdas for SAM types (without experimental compiler flags) so I added explicit JsWriter calls to some JsWriter implicit defs.