### PR TITLE
ScalaJSReact 1.4.0 compatibility & update library versions.

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -7,7 +7,7 @@ name := "scalajs-react-bridge"
 
 version := "0.7.1-SNAPSHOT"
 
-crossScalaVersions := Seq("2.12.2", "2.11.12")
+crossScalaVersions := Seq("2.12.8", "2.11.12")
 scalaVersion := crossScalaVersions.value.head
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-feature")
@@ -16,7 +16,7 @@ dependencyOverrides += "org.webjars.npm" % "js-tokens" % "3.0.2"
 
 libraryDependencies ++= {
   val scalaJsDomV = "0.9.6"
-  val scalaJsReactV = "1.3.1"
+  val scalaJsReactV = "1.4.0"
   val scalatestV = "3.0.1"
 
   Seq(

--- a/core/src/main/scala/com/payalabs/scalajs/react/bridge/WithPropsAndTagModsAndChildren.scala
+++ b/core/src/main/scala/com/payalabs/scalajs/react/bridge/WithPropsAndTagModsAndChildren.scala
@@ -1,7 +1,6 @@
 package com.payalabs.scalajs.react.bridge
 
 import japgolly.scalajs.react.vdom.{VdomElement, VdomNode}
-import japgolly.scalajs.react.vdom.Implicits._
 
 import scala.scalajs.js
 

--- a/core/src/main/scala/com/payalabs/scalajs/react/bridge/WithPropsNoChildren.scala
+++ b/core/src/main/scala/com/payalabs/scalajs/react/bridge/WithPropsNoChildren.scala
@@ -2,8 +2,6 @@ package com.payalabs.scalajs.react.bridge
 
 import scala.language.implicitConversions
 
-import japgolly.scalajs.react.vdom.Implicits._
-
 import japgolly.scalajs.react.vdom.{TagMod, VdomElement}
 
 import scala.scalajs.js

--- a/core/src/main/scala/com/payalabs/scalajs/react/bridge/package.scala
+++ b/core/src/main/scala/com/payalabs/scalajs/react/bridge/package.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.component.Js
 import japgolly.scalajs.react.vdom.{TagMod, VdomElement, VdomNode}
 import japgolly.scalajs.react.{CallbackTo, Children, CtorType}
 
+import japgolly.scalajs.react.vdom.Implicits._
 
 package object bridge extends GeneratedImplicits {
   def writerFromConversion[A](implicit conv: A => js.Any): JsWriter[A] = JsWriter(x => x)
@@ -79,8 +80,6 @@ package object bridge extends GeneratedImplicits {
   type JsComponentType = Js.ComponentSimple[Object, CtorType.Summoner.Aux[Object, Children.Varargs, CtorType.PropsAndChildren]#CT, Js.UnmountedWithRawType[Object, Null, Js.RawMounted[Object, Null]]]
 
   def extractPropsAndChildren(attrAndChildren: Seq[TagMod]): (js.Object, List[VdomNode]) = {
-    import japgolly.scalajs.react.vdom.Implicits._
-
     val b = new japgolly.scalajs.react.vdom.Builder.ToJs {}
     attrAndChildren.toTagMod.applyTo(b)
     b.addClassNameToProps()

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,12 +4,12 @@ organization := "com.payalabs"
 name := "scalajs-react-bridge-example"
 version := "0.7.1-SNAPSHOT"
 
-crossScalaVersions := Seq("2.12.2", "2.11.12")
+crossScalaVersions := Seq("2.12.8", "2.11.12")
 scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies ++= {
   val scalaJsDom = "0.9.6"
-  val scalaJsReact = "1.3.1"
+  val scalaJsReact = "1.4.0"
 
   Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")


### PR DESCRIPTION
Version `0.7.0` doesn't work with scalajs-react `1.4.0`.