### PR TITLE
Bump scalajs-react version to 1.4.2

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -16,7 +16,7 @@ dependencyOverrides += "org.webjars.npm" % "js-tokens" % "3.0.2"
 
 libraryDependencies ++= {
   val scalaJsDomV = "0.9.6"
-  val scalaJsReactV = "1.4.0"
+  val scalaJsReactV = "1.4.2"
   val scalatestV = "3.0.1"
 
   Seq(

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies ++= {
   val scalaJsDom = "0.9.6"
-  val scalaJsReact = "1.4.0"
+  val scalaJsReact = "1.4.2"
 
   Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,


### PR DESCRIPTION
Got an error when compiling scalajs-react version 1.4.2 with the current version

<img width="1253" alt="Screen Shot 2019-05-20 at 20 53 23" src="https://user-images.githubusercontent.com/14335852/58023007-59ba8f00-7b41-11e9-85e8-d78bdde06499.png">


Bumping the version fixes the problem