### PR TITLE
Cross-build for ScalaJS 1.x and 0.6.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ enablePlugins(ScalaJSPlugin)
 
 ThisBuild / version := "0.8.3-SNAPSHOT"
 
-ThisBuild / crossScalaVersions := Seq("2.13.1", "2.12.10")
+ThisBuild / crossScalaVersions := Seq("2.13.3", "2.12.12")
 ThisBuild / scalaVersion := crossScalaVersions.value.head
 
 publishTo in ThisBuild := Some("sonatype-staging" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
@@ -21,5 +21,6 @@ val scalaJsReactBridge =
   (project in file("."))
     .aggregate(core, example)
     .settings(
-      skip in publish := true
+      skip in publish := true,
+      scalaJSUseMainModuleInitializer := true
     )

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,6 +1,7 @@
 enablePlugins(ScalaJSPlugin)
+enablePlugins(JSDependenciesPlugin)
 
-val reactV = "16.5.1"
+val reactV = "16.13.1"
 
 organization := "com.payalabs"
 name := "scalajs-react-bridge"

--- a/core/src/main/scala/com/payalabs/scalajs/react/bridge/ReactBridgeComponent.scala
+++ b/core/src/main/scala/com/payalabs/scalajs/react/bridge/ReactBridgeComponent.scala
@@ -8,6 +8,7 @@ import js.Dynamic.global
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.VdomElement
 
+
 /**
  * See project's [README.md](https://github.com/payalabs/scalajs-react-bridge)
  */
@@ -37,7 +38,7 @@ abstract class ReactBridgeComponent {
 
   protected lazy val componentValue: js.Any = {
     val componentPrefixes = if (componentNamespace.trim.isEmpty) Array[String]() else componentNamespace.split('.')
-    (componentPrefixes :+ componentName).foldLeft(global)(_ selectDynamic _)
+    (componentPrefixes :+ componentName).foldLeft(global.globalThis)(_ selectDynamic _)
   }
 
   protected lazy val jsComponent: JsComponentType = JsComponent[js.Object, Children.Varargs, Null](componentValue)

--- a/example/src/main/scala/com/payalabs/scalajs/react/bridge/showcase/ShowcaseApp.scala
+++ b/example/src/main/scala/com/payalabs/scalajs/react/bridge/showcase/ShowcaseApp.scala
@@ -7,8 +7,8 @@ import org.scalajs.dom
 
 import scala.scalajs.js
 
-object ShowcaseApp extends js.JSApp {
-  def main(): Unit = {
+object ShowcaseApp {
+  def main(args: Array[String]): Unit = {
     ShowcaseComponent().renderIntoDOM(dom.document.getElementById("app-container"))
   }
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,4 +1,4 @@
 object Versions {
   val scalaJsDom = "1.0.0"
-  val scalaJsReact = "1.6.0"
+  val scalaJsReact = "1.7.3"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,14 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.33")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.1.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+
+// For Node.js with jsdom
+libraryDependencies ++= {
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.0")
+}
+
+// For jsDependencies
+{
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq(addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.1"))
+}


### PR DESCRIPTION
- Cross-build for ScalaJS 1.x and 0.6.x. Use `SCALAJS_VERSION=0.6.33 sbt` to use SJS 0.6.x (sbt-crossproject should only be used for this if Scala Native is also needed)
- Bump version ScalaJS React to 1.7.3 (SJS 1.0 support since 1.7.0)
- Using `js.Dynamic.global.globalThis` because `global` can no longer be used with `selectDynamic` after ScalaJS 1.0.
- All tests passing on 2.12 and 2.13, for both SJS 1.1.1 and 0.6.33

Resolves #46 